### PR TITLE
reqwest::Response.text()からjsonを生成するようにした

### DIFF
--- a/src/core/api.rs
+++ b/src/core/api.rs
@@ -52,13 +52,14 @@ impl Api {
         let mut res = client.post(uri).headers(headers).body(body).send().unwrap();
 
         assert!(res.status().is_success());
-        let v:Value = res.json()?;
+        let response_body = res.text().unwrap();
+        let v:Value = serde_json::from_str(response_body.as_str()).unwrap();
         if v["success"].as_i64().unwrap() == 0 {
             let msg = v["error"].as_str().unwrap();
             panic!(msg.to_string());
         }
 
-        res.text()
+        Ok(response_body)
     }
 
     fn create_body(&self) -> String {


### PR DESCRIPTION
.json()や.text()はバッファを読み切ってしまうのか、二度目の実行時には空文字しか得られなかった
よって、.text()で取得したのち、jsonに変換して操作するようにした