### PR TITLE
panicになっていたところ、Resultを返せるようにした

### DIFF
--- a/src/core/api.rs
+++ b/src/core/api.rs
@@ -52,14 +52,7 @@ impl Api {
         let uri = "https://api.zaif.jp/tapi";
         let mut res = client.post(uri).headers(headers).body(body).send()?;
 
-        let response_body = res.error_for_status()?.text()?;
-        let v: Value = serde_json::from_str(response_body.as_str())?;
-        if v["success"].as_i64() == Some(0) {
-            let msg = v["error"].as_str().unwrap();
-            panic!(msg.to_string());
-        }
-
-        Ok(response_body)
+        Ok(res.error_for_status()?.text()?)
     }
 
     fn create_body(&self) -> String {

--- a/src/core/api.rs
+++ b/src/core/api.rs
@@ -30,10 +30,9 @@ impl Api {
     }
 
     fn get(&self) -> ::Result<String> {
-        let mut resp = reqwest::get(self.uri.as_str())?;
+        let resp = reqwest::get(self.uri.as_str())?;
 
-        assert!(resp.status().is_success());
-        resp.text()
+        Ok(resp.error_for_status()?.text()?)
     }
 
     fn post(&self) -> ::Result<String> {

--- a/src/core/api.rs
+++ b/src/core/api.rs
@@ -22,21 +22,21 @@ pub struct Api {
 }
 
 impl Api {
-    pub fn exec(&self) -> reqwest::Result<String> {
+    pub fn exec(&self) -> ::Result<String> {
         match self.method {
             Method::Get => self.get(),
             Method::Post => self.post(),
         }
     }
 
-    fn get(&self) -> reqwest::Result<String> {
+    fn get(&self) -> ::Result<String> {
         let mut resp = reqwest::get(self.uri.as_str())?;
 
         assert!(resp.status().is_success());
         resp.text()
     }
 
-    fn post(&self) -> reqwest::Result<String> {
+    fn post(&self) -> ::Result<String> {
         // body生成
         let body = self.create_body();
         let sign = self.create_sign(body.as_str());

--- a/src/core/api.rs
+++ b/src/core/api.rs
@@ -1,14 +1,12 @@
 extern crate chrono;
 extern crate openssl;
 extern crate reqwest;
-extern crate serde_json;
 
 use self::reqwest::header::Headers;
 use self::chrono::Utc;
 use self::openssl::hash::MessageDigest;
 use self::openssl::pkey::PKey;
 use self::openssl::sign::Signer;
-use self::serde_json::{Error, Value};
 
 use std::collections::HashMap;
 

--- a/src/core/api.rs
+++ b/src/core/api.rs
@@ -38,13 +38,13 @@ impl Api {
     fn post(&self) -> ::Result<String> {
         // body生成
         let body = self.create_body();
-        let sign = self.create_sign(body.as_str());
-
-        let mut headers = Headers::new();
-
         let access_key = self.access_key
             .clone()
             .ok_or("AccessKeyが必要です。".to_string())?;
+        let sign = Api::create_sign(body.as_str(), &access_key);
+
+        let mut headers = Headers::new();
+
         headers.set_raw("Key", access_key.key.as_str());
         headers.set_raw("Sign", sign.as_str());
 
@@ -73,8 +73,7 @@ impl Api {
         }
         body.clone()
     }
-    fn create_sign(&self, body: &str) -> String {
-        let access_key = self.access_key.clone().unwrap();
+    fn create_sign(body: &str, access_key: &AccessKey) -> String {
         let key = PKey::hmac(access_key.secret.as_bytes()).unwrap();
         let mut signer = Signer::new(MessageDigest::sha512(), &key).unwrap();
         signer.update(body.as_bytes()).unwrap();

--- a/src/core/api.rs
+++ b/src/core/api.rs
@@ -50,7 +50,7 @@ impl Api {
 
         let client = reqwest::Client::new();
         let uri = "https://api.zaif.jp/tapi";
-        let mut res = client.post(uri).headers(headers).body(body).send()?;
+        let res = client.post(uri).headers(headers).body(body).send()?;
 
         Ok(res.error_for_status()?.text()?)
     }

--- a/src/error.rs
+++ b/src/error.rs
@@ -10,3 +10,14 @@ pub enum Error {
 }
 
 pub type Result<T> = ::std::result::Result<T, Error>;
+
+impl From<reqwest::Error> for Error {
+    fn from(error: reqwest::Error) -> Self {
+        Error::ReqwestError(error)
+    }
+}
+impl From<serde_json::Error> for Error {
+    fn from(error: serde_json::Error) -> Self {
+        Error::SerdeJsonError(error)
+    }
+}

--- a/src/error.rs
+++ b/src/error.rs
@@ -4,14 +4,9 @@ extern crate serde_json;
 use std::error::Error as StdError;
 
 #[derive(Debug)]
-pub struct Error {
-    kind: Kind,
+pub enum Error {
+    ReqwestError(reqwest::Error),
+    SerdeJsonError(serde_json::Error),
 }
 
 pub type Result<T> = ::std::result::Result<T, Error>;
-
-#[derive(Debug)]
-enum Kind {
-    Network(reqwest::Error),
-    Json(serde_json::Error),
-}

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,0 +1,15 @@
+extern crate reqwest;
+extern crate serde_json;
+
+use std::error::Error as StdError;
+
+#[derive(Debug)]
+pub struct Error {
+    kind: Kind,
+}
+
+#[derive(Debug)]
+enum Kind {
+    Network(reqwest::Error),
+    Json(serde_json::Error),
+}

--- a/src/error.rs
+++ b/src/error.rs
@@ -7,6 +7,7 @@ use std::error::Error as StdError;
 pub enum Error {
     ReqwestError(reqwest::Error),
     SerdeJsonError(serde_json::Error),
+    SimpleError(String),
 }
 
 pub type Result<T> = ::std::result::Result<T, Error>;
@@ -19,5 +20,10 @@ impl From<reqwest::Error> for Error {
 impl From<serde_json::Error> for Error {
     fn from(error: serde_json::Error) -> Self {
         Error::SerdeJsonError(error)
+    }
+}
+impl From<String> for Error {
+    fn from(error: String) -> Self {
+        Error::SimpleError(error)
     }
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -8,6 +8,8 @@ pub struct Error {
     kind: Kind,
 }
 
+pub type Result<T> = ::std::result::Result<T, Error>;
+
 #[derive(Debug)]
 enum Kind {
     Network(reqwest::Error),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,6 +4,7 @@ extern crate serde_derive;
 #[macro_use]
 mod builder;
 mod core;
+mod error;
 
 pub mod public_api;
 pub mod trade_api;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,6 +9,7 @@ mod error;
 pub mod public_api;
 pub mod trade_api;
 
+pub use error::{Error, Result};
 pub use core::AccessKey;
 
 #[cfg(test)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -156,7 +156,7 @@ fn call_trade(access_key: &AccessKey) {
             Ok(())
         }) {
         Ok(_) => println!("Complete trade and cancel"),
-        Err(e) => println!("Error: {}", e),
+        Err(e) => println!("Error: {:?}", e),
     }
 }
 

--- a/src/public_api/currencies.rs
+++ b/src/public_api/currencies.rs
@@ -8,8 +8,8 @@ builder!(CurrenciesBuilder => Currencies {
 });
 
 impl Currencies {
-    pub fn exec(&self) -> serde_json::Result<Vec<CurrenciesResponse>> {
-        serde_json::from_value(<Self as PublicApi>::exec(&self)?)
+    pub fn exec(&self) -> ::Result<Vec<CurrenciesResponse>> {
+        Ok(serde_json::from_value(<Self as PublicApi>::exec(&self)?)?)
     }
 }
 

--- a/src/public_api/currency_pairs.rs
+++ b/src/public_api/currency_pairs.rs
@@ -8,8 +8,8 @@ builder!(CurrencyPairsBuilder => CurrencyPairs {
 });
 
 impl CurrencyPairs {
-    pub fn exec(&self) -> serde_json::Result<Vec<CurrencyPairsResponse>> {
-        serde_json::from_value(<Self as PublicApi>::exec(&self)?)
+    pub fn exec(&self) -> ::Result<Vec<CurrencyPairsResponse>> {
+        Ok(serde_json::from_value(<Self as PublicApi>::exec(&self)?)?)
     }
 }
 

--- a/src/public_api/depth.rs
+++ b/src/public_api/depth.rs
@@ -8,8 +8,8 @@ builder!(DepthBuilder => Depth {
 });
 
 impl Depth {
-    pub fn exec(&self) -> serde_json::Result<DepthResponse> {
-        serde_json::from_value(<Self as PublicApi>::exec(&self)?)
+    pub fn exec(&self) -> ::Result<DepthResponse> {
+        Ok(serde_json::from_value(<Self as PublicApi>::exec(&self)?)?)
     }
 }
 

--- a/src/public_api/last_price.rs
+++ b/src/public_api/last_price.rs
@@ -8,8 +8,8 @@ builder!(LastPriceBuilder => LastPrice {
 });
 
 impl LastPrice {
-    pub fn exec(&self) -> serde_json::Result<LastPriceResponse> {
-        serde_json::from_value(<Self as PublicApi>::exec(&self)?)
+    pub fn exec(&self) -> ::Result<LastPriceResponse> {
+        Ok(serde_json::from_value(<Self as PublicApi>::exec(&self)?)?)
     }
 }
 

--- a/src/public_api/mod.rs
+++ b/src/public_api/mod.rs
@@ -22,16 +22,13 @@ mod ticker;
 trait PublicApi {
     fn action(&self) -> &str;
     fn parameter(&self) -> &str;
-    fn exec(&self) -> serde_json::Result<Value> {
+    fn exec(&self) -> ::Result<Value> {
         let endpoint = "https://api.zaif.jp/api/1";
         let api = ApiBuilder::new()
             .uri(format!("{}/{}/{}", endpoint, self.action(), self.parameter()).as_str())
             .finalize();
 
-        let res = match api.exec() {
-            Ok(res) => res,
-            Err(e) => panic!("reqwest Error: {}", e),
-        };
-        serde_json::from_str(res.as_str())
+        let res = api.exec()?;
+        Ok(serde_json::from_str(res.as_str())?)
     }
 }

--- a/src/public_api/ticker.rs
+++ b/src/public_api/ticker.rs
@@ -8,8 +8,8 @@ builder!(TickerBuilder => Ticker {
 });
 
 impl Ticker {
-    pub fn exec(&self) -> serde_json::Result<TickerResponse> {
-        serde_json::from_value(<Self as PublicApi>::exec(&self)?)
+    pub fn exec(&self) -> ::Result<TickerResponse> {
+        Ok(serde_json::from_value(<Self as PublicApi>::exec(&self)?)?)
     }
 }
 

--- a/src/public_api/trades.rs
+++ b/src/public_api/trades.rs
@@ -8,8 +8,8 @@ builder!(TradesBuilder => Trades {
 });
 
 impl Trades {
-    pub fn exec(&self) -> serde_json::Result<Vec<TradesResponse>> {
-        serde_json::from_value(<Self as PublicApi>::exec(&self)?)
+    pub fn exec(&self) -> ::Result<Vec<TradesResponse>> {
+        Ok(serde_json::from_value(<Self as PublicApi>::exec(&self)?)?)
     }
 }
 

--- a/src/trade_api/active_orders.rs
+++ b/src/trade_api/active_orders.rs
@@ -12,8 +12,8 @@ builder!(ActiveOrdersBuilder => ActiveOrders {
 });
 
 impl ActiveOrders {
-    pub fn exec(&self) -> serde_json::Result<HashMap<u64, ActiveOrdersResponse>> {
-        serde_json::from_value(<Self as TradeApi>::exec(&self)?)
+    pub fn exec(&self) -> ::Result<HashMap<u64, ActiveOrdersResponse>> {
+        Ok(serde_json::from_value(<Self as TradeApi>::exec(&self)?)?)
     }
 }
 

--- a/src/trade_api/cancel_order.rs
+++ b/src/trade_api/cancel_order.rs
@@ -13,8 +13,8 @@ builder!(CancelOrderBuilder => CancelOrder {
 });
 
 impl CancelOrder {
-    pub fn exec(&self) -> serde_json::Result<CancelOrderResponse> {
-        serde_json::from_value(<Self as TradeApi>::exec(&self)?)
+    pub fn exec(&self) -> ::Result<CancelOrderResponse> {
+        Ok(serde_json::from_value(<Self as TradeApi>::exec(&self)?)?)
     }
 }
 

--- a/src/trade_api/get_id_info.rs
+++ b/src/trade_api/get_id_info.rs
@@ -11,9 +11,9 @@ builder!(GetIdInfoBuilder => GetIdInfo {
 });
 
 impl GetIdInfo {
-    pub fn exec(&self) -> serde_json::Result<GetIdInfoResponse> {
+    pub fn exec(&self) -> ::Result<GetIdInfoResponse> {
         let result = <Self as TradeApi>::exec(&self)?;
-        serde_json::from_value(result["user"].clone())
+        Ok(serde_json::from_value(result["user"].clone())?)
     }
 }
 

--- a/src/trade_api/get_info2.rs
+++ b/src/trade_api/get_info2.rs
@@ -11,8 +11,8 @@ builder!(GetInfo2Builder => GetInfo2 {
 });
 
 impl GetInfo2 {
-    pub fn exec(&self) -> serde_json::Result<GetInfo2Response> {
-        serde_json::from_value(<Self as TradeApi>::exec(&self)?)
+    pub fn exec(&self) -> ::Result<GetInfo2Response> {
+        Ok(serde_json::from_value(<Self as TradeApi>::exec(&self)?)?)
     }
 }
 

--- a/src/trade_api/get_personal_info.rs
+++ b/src/trade_api/get_personal_info.rs
@@ -11,8 +11,8 @@ builder!(GetPersonalInfoBuilder => GetPersonalInfo {
 });
 
 impl GetPersonalInfo {
-    pub fn exec(&self) -> serde_json::Result<GetPersonalInfoResponse> {
-        serde_json::from_value(<Self as TradeApi>::exec(&self)?)
+    pub fn exec(&self) -> ::Result<GetPersonalInfoResponse> {
+        Ok(serde_json::from_value(<Self as TradeApi>::exec(&self)?)?)
     }
 }
 

--- a/src/trade_api/mod.rs
+++ b/src/trade_api/mod.rs
@@ -27,7 +27,7 @@ trait TradeApi {
     fn parameters(&self) -> HashMap<String, String>;
     fn access_key(&self) -> &AccessKey;
 
-    fn exec(&self) -> serde_json::Result<Value> {
+    fn exec(&self) -> ::Result<Value> {
         let mut param = self.parameters().clone();
         param.insert("method".to_string(), self.method().to_string());
 
@@ -38,13 +38,10 @@ trait TradeApi {
             .param(param)
             .finalize();
 
-        let res = match api.exec() {
-            Ok(res) => res,
-            Err(e) => panic!("reqwest Error: {}", e),
-        };
+        let res = api.exec()?;
         let result: Value = serde_json::from_str(res.as_str())?;
-        if result["success"].as_i64().unwrap() != 1 {
-            panic!("error: {}", result["error"]);
+        if result["success"].as_i64() != Some(1) {
+            return Err(format!("error: {}", result["error"]).into());
         }
         Ok(result["return"].clone())
     }

--- a/src/trade_api/trade.rs
+++ b/src/trade_api/trade.rs
@@ -33,8 +33,8 @@ builder!(TradeBuilder => Trade {
 });
 
 impl Trade {
-    pub fn exec(&self) -> serde_json::Result<TradeResponse> {
-        serde_json::from_value(<Self as TradeApi>::exec(&self)?)
+    pub fn exec(&self) -> ::Result<TradeResponse> {
+        Ok(serde_json::from_value(<Self as TradeApi>::exec(&self)?)?)
     }
 }
 

--- a/src/trade_api/trade_history.rs
+++ b/src/trade_api/trade_history.rs
@@ -33,8 +33,8 @@ builder!(TradeHistoryBuilder => TradeHistory {
 });
 
 impl TradeHistory {
-    pub fn exec(&self) -> serde_json::Result<HashMap<u64, TradeHistoryResponse>> {
-        serde_json::from_value(<Self as TradeApi>::exec(&self)?)
+    pub fn exec(&self) -> ::Result<HashMap<u64, TradeHistoryResponse>> {
+        Ok(serde_json::from_value(<Self as TradeApi>::exec(&self)?)?)
     }
 }
 


### PR DESCRIPTION
# 目的

#50 の解決

HTTP通信側でトラブルがあった場合に`Panic`を起こしてしまうので、使い勝手が悪くなっていた。
各依存crateのErrorを掴んだとき、独自に定義した`Error`に包んで`Result`に載せるようにした。

この対応により、`zaif_api`crateを利用する側でエラーハンドリングができるようになった。