### PR TITLE
v0.5.0のリリース

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zaif-api"
-version = "0.4.0"
+version = "0.5.0"
 authors = ["yajamon <yajamon.tatsuki@gmail.com>"]
 
 license = "MIT"


### PR DESCRIPTION
https://github.com/yajamon/zaif-api-rust/issues?utf8=%E2%9C%93&q=+is%3Aissue+milestone%3Av%2F0.5.0+